### PR TITLE
First draft of the plugin descriptor changes for "special destinations" ...

### DIFF
--- a/modules/core/client-api/src/main/resources/rhq-plugin.xsd
+++ b/modules/core/client-api/src/main/resources/rhq-plugin.xsd
@@ -497,6 +497,15 @@
 
    <!-- == Bundle Target ================================================== -->
 
+   <xs:simpleType name="valueContextChoice">
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="pluginConfiguration"></xs:enumeration>
+        <xs:enumeration value="resourceConfiguration"></xs:enumeration>
+        <xs:enumeration value="measurementTrait"></xs:enumeration>
+        <xs:enumeration value="fileSystem"></xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+   
    <xs:element name="bundle-target">
         <xs:annotation>
            <xs:appinfo>
@@ -509,49 +518,96 @@
         </xs:annotation>
         <xs:complexType>
            <xs:sequence>
-              <xs:element name="destination-base-dir" maxOccurs="unbounded" minOccurs="1">
-                  <xs:complexType>
-                       <xs:annotation>
-                           <xs:documentation>
-                              Defines where a bundle can be deployed under the resource.
-                              You must define one destination base directory, but may define more.
-                              Each destination base directory's value is obtained from a particular context
-                              (e.g. in the resource's plugin configuration or its resource configuration).
-                              Within that context, the base directory value is obtained by looking up the named value in the given context.
-                              For example, if the value-name is "install.dir" and the value-context is "pluginConfiguration",
-                              then the destination base directory value is obtained by getting the "install.dir" property value
-                              found in the resource's plugin configuration.
-                           </xs:documentation>
-                       </xs:annotation>
-                       <xs:sequence>
-                          <xs:element name="value-context">
-                              <xs:simpleType>
-                                  <xs:restriction base="xs:string">
-                                      <xs:enumeration value="pluginConfiguration"></xs:enumeration>
-                                      <xs:enumeration value="resourceConfiguration"></xs:enumeration>
-                                      <xs:enumeration value="measurementTrait"></xs:enumeration>
-                                      <xs:enumeration value="fileSystem"></xs:enumeration>
-                                  </xs:restriction>
-                              </xs:simpleType>
-                          </xs:element>
-                          <xs:element name="value-name" type="xs:string"></xs:element>
-                      </xs:sequence>
-                      <xs:attribute name="name" type="xs:string" use="required">
-                          <xs:annotation>
-                              <xs:documentation>
-                                  The name given to identify this particular destination base directory.
-                              </xs:documentation>
-                          </xs:annotation>
-                      </xs:attribute>
-                      <xs:attribute name="description" type="xs:string" use="optional">
-                          <xs:annotation>
-                              <xs:documentation>
-                                  An explanation to the user to describe what this destination location is. 
-                              </xs:documentation>
-                          </xs:annotation>
-                      </xs:attribute>
-                  </xs:complexType>
-              </xs:element>
+              <xs:choice minOccurs="1" maxOccurs="unbounded">
+                 <xs:element name="special-destination">
+                    <xs:annotation>
+                        <xs:documentation>
+                            This type of destination is used for bundle types that require specialized handling.
+                            The "bundle-type" attribute specifies the type of bundle that is deployable to such destination.
+                            The bundles of such type are handled using a bundle deployer (bundle plugin) that then 
+                            requires certain configuration variables to be passed to it. These variables are specified
+                            using the "value-reference" child elements.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="value-reference" minOccurs="0" maxOccurs="unbounded">
+                             <xs:complexType>                            
+                                <xs:attribute name="reference-name" type="xs:string" use="optional">
+                                   <xs:annotation>
+                                     <xs:documentation>
+                                            The name of the value as passed to the bundle deployer. If not specified,
+                                            it defaults to the name specified by the "name" attribute.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>                            
+                                <xs:attribute name="context" use="required" type="rhq:valueContextChoice">
+                                    <xs:annotation>
+                                        <xs:documentation>The "context" where to look for a value specified by the "name" attribute.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="name" type="xs:string" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The name of the value to be passed to to bundle deployer. This is either
+                                            the name of a property in the plugin or resource configuration, the name
+                                            of a measurement trait.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                           </xs:element>              
+                        </xs:sequence>
+                        <xs:attribute name="name" type="xs:string" use="required" />
+                        <xs:attribute name="description" type="xs:string" use="optional"/>
+                        <xs:attribute name="bundle-type" type="xs:string" use="required">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The name of the type of bundle that can be deployed into this destination.
+                                    This determines the bundle deployer that is responsible for deploying the bundle.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                 </xs:element>
+                 <xs:element name="destination-base-dir">
+                    <xs:annotation>
+                       <xs:documentation>
+                          Defines where a bundle can be deployed under the resource.
+                          Each destination base directory's value is obtained from a particular context
+                          (e.g. in the resource's plugin configuration or its resource configuration).
+                          Within that context, the base directory value is obtained by looking up the named value in the given context.
+                          For example, if the value-name is "install.dir" and the value-context is "pluginConfiguration",
+                          then the destination base directory value is obtained by getting the "install.dir" property value
+                          found in the resource's plugin configuration.
+                       
+                          In contrast to the "special-destination" destination specification, this destination
+                          specification is generic and can be used by any bundle deployer that only requires
+                          a "base directory" as its configuration to kick of the deployment.
+                       </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                         <xs:sequence>
+                            <xs:element name="value-context" type="rhq:valueContextChoice" />
+                            <xs:element name="value-name" type="xs:string"></xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="name" type="xs:string" use="required">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The name given to identify this particular destination base directory.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="description" type="xs:string" use="optional">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    An explanation to the user to describe what this destination location is. 
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                 </xs:element>
+              </xs:choice>
           </xs:sequence>
        </xs:complexType>
    </xs:element>


### PR DESCRIPTION
First draft of the plugin descriptor changes for "special destinations" support in bundles,

which are going to enable using specialized bundle deployers not necessarily
using file system and a "base path" to do their deployment.

An example bundle target:

``` xml
<bundle-target>
   <destination-base-dir name="Deploy Directory" description="The deployment directory for a standalone server">
      <value-context>measurementTrait</value-context>
      <value-name>deployDir</value-name>
   </destination-base-dir>
   <special-destination name="Patch Installer" description="Accepts JBoss AS patches and installs them to a standalone server" bundle-type="JBoss AS Patch Bundle">
      <value-reference reference-name="host" context="pluginConfiguration" name="hostname"/>
      <value-reference context="pluginConfiguration" name="port"/>
      <value-reference context="pluginConfiguration" name="user"/>
      <value-reference context="pluginConfiguration" name="password"/>
   </special-destination>
</bundle-target>
```
