### PR TITLE
Server side changes for provisioning subsystem

### DIFF
--- a/modules/core/domain/src/main/java/org/rhq/core/domain/criteria/ArtifactCriteria.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/criteria/ArtifactCriteria.java
@@ -1,0 +1,19 @@
+package org.rhq.core.domain.criteria;
+
+import org.rhq.core.domain.provisioning.Artifact;
+
+/**
+ * TODO This criteria won't be handled "normally" because it will be processed by the repository connectors.
+ * Make sure we can query everything this class can define in the connectors.
+ *
+ * @author Lukas Krejci
+ */
+public class ArtifactCriteria extends Criteria {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Class<?> getPersistentClass() {
+        return Artifact.class;
+    }
+}

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/Artifact.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/Artifact.java
@@ -1,0 +1,200 @@
+/*
+ * RHQ Management Platform
+ * Copyright (C) 2013 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+package org.rhq.core.domain.provisioning;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.rhq.core.domain.configuration.Configuration;
+
+/**
+ * Represents a file in a content repository.
+ *
+ * @author Lukas Krejci
+ */
+public class Artifact implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final URI repositoryUri;
+    private final String identifier;
+    private String path;
+    private String mediaType;
+    private String version;
+    private Configuration definition;
+    private Map<String, String> metadata;
+
+    //for GWT
+    protected Artifact() {
+        repositoryUri = null;
+        identifier = null;
+    }
+
+    public Artifact(URI repositoryUri, String identifier, String path, String mediaType, String version) {
+        if (repositoryUri == null) {
+            throw new IllegalArgumentException("repositoryUri can't be null");
+        }
+
+        if (identifier == null) {
+            throw new IllegalArgumentException("identifier can't be null.");
+        }
+
+        if (path == null) {
+            throw new IllegalArgumentException("path can't be null.");
+        }
+
+        if (mediaType == null) {
+            throw new IllegalArgumentException("mediaType can't be null.");
+        }
+
+        this.repositoryUri = repositoryUri;
+        this.identifier = identifier;
+        this.path = path;
+        this.mediaType = mediaType;
+        this.version = version;
+    }
+
+    /**
+     * @return an identifier uniquely identifying the artifact within the {@link #getRepositoryUri() repository}.
+     */
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    /**
+     * @return the media type of the artifact
+     */
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    public void setMediaType(String mediaType) {
+        if (mediaType == null) {
+            throw new IllegalArgumentException("mediaType can't be null.");
+        }
+
+        this.mediaType = mediaType;
+    }
+
+    /**
+     * @return the path to the artifact (including the artifact's name) in the repository. The path separator is always '/'.
+     */
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        if (path == null) {
+            throw new IllegalArgumentException("path can't be null.");
+        }
+
+        this.path = path;
+    }
+
+    /**
+     * @return the additional metadata of the artifact, i.e. the metadata
+     */
+    public Map<String, String> getMetadata() {
+        if (metadata == null) {
+            metadata = new HashMap<String, String>();
+        }
+
+        return metadata;
+    }
+
+    /**
+     * @return the URI of the repository this artifact comes from
+     */
+    public URI getRepositoryUri() {
+        return repositoryUri;
+    }
+
+    /**
+     * @return the version of the artifact
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * This is distinct from {@link #getMetadata() metadata}. The definition of the artifact is a set of additional properties
+     * required to describe or define the artifact in its repository.
+     *
+     * @return Additional definitions that describe the artifact in the repository.
+     */
+    public Configuration getDefinition() {
+        return definition;
+    }
+
+    public void setDefinition(Configuration definition) {
+        this.definition = definition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Artifact)) {
+            return false;
+        }
+
+        Artifact that = (Artifact) o;
+
+        if (!identifier.equals(that.identifier)) {
+            return false;
+        }
+        if (!repositoryUri.equals(that.repositoryUri)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = repositoryUri.hashCode();
+        result = 31 * result + identifier.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder(this.getClass().getSimpleName());
+        sb.append("[");
+        sb.append("identifier='").append(identifier).append('\'');
+        sb.append(", mediaType='").append(mediaType).append('\'');
+        sb.append(", path='").append(path).append('\'');
+        sb.append(", repositoryUri=").append(repositoryUri);
+        sb.append(", version='").append(version).append('\'');
+        addToString(sb);
+        sb.append(']');
+        return sb.toString();
+    }
+
+    protected void addToString(StringBuilder bld) {
+
+    }
+}

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ArtifactIdentifier.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ArtifactIdentifier.java
@@ -1,0 +1,98 @@
+package org.rhq.core.domain.provisioning;
+
+import java.io.Serializable;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+/**
+ * @author Lukas Krejci
+ */
+@Entity
+@Table(name = "RHQ_ARTIFACT_IDENTIFIER")
+public final class ArtifactIdentifier implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @Column(name = "ID", nullable = false)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "RHQ_ARTIFACT_ID_ID_SEQ")
+    private int id;
+
+    @JoinColumn(name = "CONTENT_REPO_ID", referencedColumnName = "ID")
+    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER, optional = false)
+    private ContentRepository repository;
+
+    @Column(name = "PATH", nullable = false)
+    private String path;
+
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public ContentRepository getRepository() {
+        return repository;
+    }
+
+    public void setRepository(ContentRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ArtifactIdentifier)) {
+            return false;
+        }
+
+        ArtifactIdentifier that = (ArtifactIdentifier) o;
+
+        if (!path.equals(that.path)) {
+            return false;
+        }
+        if (!repository.equals(that.repository)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = repository.hashCode();
+        result = 31 * result + path.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ArtifactIdentifier[");
+        sb.append("id=").append(id);
+        sb.append(", path='").append(path).append('\'');
+        sb.append(", repository.id=").append(repository.getId());
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/BundleRecipe.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/BundleRecipe.java
@@ -1,0 +1,32 @@
+package org.rhq.core.domain.provisioning;
+
+import java.net.URI;
+
+import org.rhq.core.domain.configuration.definition.ConfigurationDefinition;
+
+/**
+ * @author Lukas Krejci
+ */
+public final class BundleRecipe extends Artifact {
+
+    private static final long serialVersionUID = 1L;
+
+    private ConfigurationDefinition configurationDefinition;
+
+    public BundleRecipe(URI repositoryUri, String identifier, String path, String mimetype, String version) {
+        super(repositoryUri, identifier, path, mimetype, version);
+    }
+
+    public ConfigurationDefinition getConfigurationDefinition() {
+        return configurationDefinition;
+    }
+
+    public void setConfigurationDefinition(ConfigurationDefinition configurationDefinition) {
+        this.configurationDefinition = configurationDefinition;
+    }
+
+    @Override
+    protected void addToString(StringBuilder bld) {
+        bld.append(", configurationDefinition=").append(configurationDefinition).append('\n');
+    }
+}

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ContentRepository.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ContentRepository.java
@@ -1,0 +1,158 @@
+package org.rhq.core.domain.provisioning;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.rmi.activation.Activatable;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.PostLoad;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+
+import org.rhq.core.domain.configuration.Configuration;
+
+/**
+ * @author Lukas Krejci
+ */
+@Entity
+@Table(name = "RHQ_PRV_CONTENT_REPO")
+public final class ContentRepository implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @Column(name = "ID", nullable = false)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "RHQ_CONTENT_REPO_ID_SEQ")
+    private int id;
+
+    private int kachna;
+
+    private transient URI uri;
+
+    @Column(name = "URI", nullable = false)
+    private String uriString;
+
+    @Column(name = "NAME", nullable = false)
+    private String name;
+
+    @Column(name = "PLUGIN", nullable = false)
+    private String connectorPlugin;
+
+    @JoinColumn(name = "CONFIG_ID", referencedColumnName = "ID")
+    @OneToOne(cascade = CascadeType.ALL)
+    private Configuration connectorConfiguration;
+
+    @Column(name = "SYNC_SCHEDULE")
+    private String syncSchedule;
+
+    @PostLoad
+    protected void initUri() {
+        uri = URI.create(uriString);
+    }
+
+    @PrePersist
+    @PreUpdate
+    protected void uriToString() {
+        uriString = uri.toString();
+    }
+
+    public Configuration getConnectorConfiguration() {
+        return connectorConfiguration;
+    }
+
+    public void setConnectorConfiguration(Configuration connectorConfiguration) {
+        this.connectorConfiguration = connectorConfiguration;
+    }
+
+    public String getConnectorPlugin() {
+        return connectorPlugin;
+    }
+
+    public void setConnectorPlugin(String connectorPlugin) {
+        if (connectorPlugin == null) {
+            throw new IllegalArgumentException("connectorPlugin can't be null.");
+        }
+        this.connectorPlugin = connectorPlugin;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name can't be null.");
+        }
+
+        this.name = name;
+    }
+
+    public String getSyncSchedule() {
+        return syncSchedule;
+    }
+
+    public void setSyncSchedule(String syncSchedule) {
+        this.syncSchedule = syncSchedule;
+    }
+
+    public URI getUri() {
+        return uri;
+    }
+
+    public void setUri(URI uri) {
+        if (uri == null) {
+            throw new IllegalArgumentException("uri can't be null.");
+        }
+
+        this.uri = uri;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ContentRepository)) {
+            return false;
+        }
+
+        ContentRepository that = (ContentRepository) o;
+
+        if (!uri.equals(that.uri)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return uri.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ContentRepository[");
+        sb.append("id=").append(id);
+        sb.append(", name='").append(name).append('\'');
+        sb.append(", uri=").append(uri);
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/Deployment.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/Deployment.java
@@ -1,0 +1,344 @@
+/*
+ * RHQ Management Platform
+ * Copyright (C) 2013 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+package org.rhq.core.domain.provisioning;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.rhq.core.domain.configuration.Configuration;
+
+/**
+ * Represents a single deployment of an artifact.
+ *
+ * @author Lukas Krejci
+ */
+public final class Deployment {
+
+    public enum Status {
+        PENDING("Pending"),
+        IN_PROGRESS("In Progress"),
+        MIXED("Mixed"),
+        SUCCESS("Success"),
+        FAILURE("Failure");
+
+        private String displayName;
+
+        Status(String displayName) {
+            this.displayName = displayName;
+        }
+
+        public String toString() {
+            return displayName;
+        }
+    }
+
+    public static final class OnResource {
+        private final int resourceId;
+        private Status status;
+
+        public OnResource(int resourceId) {
+            this.resourceId = resourceId;
+        }
+
+        public int getResourceId() {
+            return resourceId;
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        public void setStatus(Status status) {
+            this.status = status;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (!(o instanceof OnResource)) {
+                return false;
+            }
+
+            OnResource that = (OnResource) o;
+
+            if (resourceId != that.resourceId) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return resourceId;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("OnResource[");
+            sb.append("resourceId=").append(resourceId);
+            sb.append(", status=").append(status);
+            sb.append(']');
+            return sb.toString();
+        }
+
+
+    }
+
+    public static final class DeploymentBuilder {
+        private Deployment deployment;
+
+        private DeploymentBuilder(Artifact artifact, int destinationId, Integer resourceGroupId, Integer resourceId) {
+            deployment = new Deployment(artifact, destinationId, resourceGroupId, resourceId);
+        }
+
+        public DeploymentBuilder withDeploymentConfiguration(Configuration deploymentConfiguration) {
+            deployment.deploymentConfiguration = deploymentConfiguration;
+            return this;
+        }
+
+        public DeploymentBuilder withDestinationConfiguration(Configuration destinationConfiguration) {
+            deployment.destinationConfiguration = destinationConfiguration;
+            return this;
+        }
+
+        public DeploymentBuilder withName(String name) {
+            deployment.name = name;
+            return this;
+        }
+
+        public DeploymentBuilder withStatus(Status status) {
+            deployment.status = status;
+            return this;
+        }
+
+        public DeploymentBuilder withLive(boolean live) {
+            deployment.live = live;
+            return this;
+        }
+
+        public DeploymentBuilder withSubjectName(String subjectName) {
+            deployment.subjectName = subjectName;
+            return this;
+        }
+
+        public DeploymentBuilder withErrorMessage(String errorMessage) {
+            deployment.errorMessage = errorMessage;
+            return this;
+        }
+
+        public DeploymentBuilder onResources(OnResource... resources) {
+            deployment.getResources().addAll(Arrays.asList(resources));
+            return this;
+        }
+
+        public Deployment build() {
+            return deployment;
+        }
+    }
+
+    private final Artifact artifact;
+    private Configuration deploymentConfiguration;
+    private Configuration destinationConfiguration;
+    private String name;
+    private Status status;
+    private boolean live;
+    private String subjectName;
+    private String errorMessage;
+    private final int destinationId;
+    private final Integer resourceGroupId;
+    private final Integer resourceId;
+    private final Set<OnResource> resources = new HashSet<OnResource>();
+
+    public static DeploymentBuilder createGroupDeployment(Artifact artifact, int destinationId, int resourceGroupId) {
+        return new DeploymentBuilder(artifact, destinationId, resourceGroupId, null);
+    }
+
+    public static DeploymentBuilder createResourceDeployment(Artifact artifact, int destinationId, int resourceId) {
+        return new DeploymentBuilder(artifact, destinationId, null, resourceId);
+    }
+
+    //for GWT
+    private Deployment() {
+        artifact = null;
+        destinationId = 0;
+        resourceGroupId = null;
+        resourceId = null;
+    }
+
+    protected Deployment(Artifact artifact, int destinationId, Integer resourceGroupId, Integer resourceId) {
+        if (artifact == null) {
+            throw new IllegalArgumentException("artifact can't be null.");
+        }
+
+        if (resourceGroupId == null && resourceId == null) {
+            throw new IllegalArgumentException(
+                "Exactly one of resourceGroupId or resourceId must not be null, but both are null.");
+        }
+
+        if (resourceGroupId != null && resourceId != null) {
+            throw new IllegalArgumentException(
+                "Exactly one of resourceGroupId or resourceId must not be null, but both are not null.");
+        }
+
+        if (destinationId == 0) {
+            throw new IllegalArgumentException("destinationId must not be 0.");
+        }
+
+        this.artifact = artifact;
+        this.resourceGroupId = resourceGroupId;
+        this.resourceId = resourceId;
+        this.destinationId = destinationId;
+    }
+
+    public Artifact getArtifact() {
+        return artifact;
+    }
+
+    public Configuration getDeploymentConfiguration() {
+        return deploymentConfiguration;
+    }
+
+    public void setDeploymentConfiguration(Configuration deploymentConfiguration) {
+        this.deploymentConfiguration = deploymentConfiguration;
+    }
+
+    public Configuration getDestinationConfiguration() {
+        return destinationConfiguration;
+    }
+
+    public void setDestinationConfiguration(Configuration destinationConfiguration) {
+        this.destinationConfiguration = destinationConfiguration;
+    }
+
+    public int getDestinationId() {
+        return destinationId;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public boolean isLive() {
+        return live;
+    }
+
+    public void setLive(boolean live) {
+        this.live = live;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getResourceGroupId() {
+        return resourceGroupId;
+    }
+
+    public Integer getResourceId() {
+        return resourceId;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getSubjectName() {
+        return subjectName;
+    }
+
+    public void setSubjectName(String subjectName) {
+        this.subjectName = subjectName;
+    }
+
+    public Set<OnResource> getResources() {
+        return resources;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Deployment)) {
+            return false;
+        }
+
+        Deployment that = (Deployment) o;
+
+        if (destinationId != that.destinationId) {
+            return false;
+        }
+        if (!artifact.equals(that.artifact)) {
+            return false;
+        }
+        if (resourceGroupId != null ? !resourceGroupId.equals(that.resourceGroupId) : that.resourceGroupId != null) {
+            return false;
+        }
+        if (resourceId != null ? !resourceId.equals(that.resourceId) : that.resourceId != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = artifact.hashCode();
+        result = 31 * result + destinationId;
+        result = 31 * result + (resourceGroupId != null ? resourceGroupId.hashCode() : 0);
+        result = 31 * result + (resourceId != null ? resourceId.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Deployment[");
+        sb.append("artifact=").append(artifact);
+        sb.append(", deploymentConfiguration=").append(deploymentConfiguration);
+        sb.append(", destinationConfiguration=").append(destinationConfiguration);
+        sb.append(", destinationId=").append(destinationId);
+        sb.append(", errorMessage='").append(errorMessage).append('\'');
+        sb.append(", live=").append(live);
+        sb.append(", name='").append(name).append('\'');
+        sb.append(", resourceGroupId=").append(resourceGroupId);
+        sb.append(", resourceId=").append(resourceId);
+        sb.append(", status=").append(status);
+        sb.append(", subjectName='").append(subjectName).append('\'');
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/MediaTypes.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/MediaTypes.java
@@ -1,0 +1,53 @@
+package org.rhq.core.domain.provisioning;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.ws.rs.core.MediaType;
+
+import org.rhq.core.domain.util.StringUtils;
+
+/**
+ * A helper class to parse a set of media types from and to strings.
+ *
+ * @author Lukas Krejci
+ */
+final class MediaTypes {
+
+    private static final StringUtils.ObjectFromStringFactory<MediaType> FROM_STRING_FACTORY = new StringUtils.ObjectFromStringFactory<MediaType>() {
+        @Override
+        public MediaType fromString(String s) {
+            return MediaType.valueOf(s);
+        }
+    };
+
+    private MediaTypes() {
+
+    }
+
+    /**
+     * Converts a whitespace separated list of media type strings into a set
+     * of media type instances.
+     *
+     * @param value the string to parse
+     * @return parsed media types
+     */
+    public static Set<MediaType> parse(String value) {
+        HashSet<MediaType> ret = new HashSet<MediaType>();
+
+        StringUtils.fill(ret, value, " ", true, FROM_STRING_FACTORY);
+
+        return ret;
+    }
+
+    /**
+     * Converts the provided set of media types into a space-separated list of
+     * their string representations.
+     *
+     * @param mediaTypes the media types
+     * @return the string representing the set of media types
+     */
+    public static String toString(Set<MediaType> mediaTypes) {
+        return StringUtils.join(mediaTypes, " ", false);
+    }
+}

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ProvisioningDestination.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ProvisioningDestination.java
@@ -1,0 +1,111 @@
+package org.rhq.core.domain.provisioning;
+
+import java.io.Serializable;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import org.rhq.core.domain.configuration.Configuration;
+
+/**
+ * @author Lukas Krejci
+ */
+@Entity
+@Table(name = "RHQ_PRV_DESTINATION")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "DEST_TYPE", discriminatorType = DiscriminatorType.CHAR)
+public abstract class ProvisioningDestination implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @Column(name = "ID", nullable = false)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "RHQ_PRV_DEST_ID_SEQ")
+    private int id;
+
+    @Column(name = "NAME", nullable = false)
+    private String name;
+
+    @JoinColumn(name = "CONF_ID", referencedColumnName = "ID")
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    private Configuration configuration;
+
+    @JoinColumn(name = "DESTINATION_ID", referencedColumnName = "ID", nullable = false)
+    @ManyToOne
+    private ProvisioningDestinationDefinition definition;
+
+    @JoinColumn(name = "TYPE_ID", referencedColumnName = "ID", nullable = false)
+    @ManyToOne
+    private ProvisioningTypeDefinition type;
+
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    public ProvisioningDestinationDefinition getDefinition() {
+        return definition;
+    }
+
+    public void setDefinition(ProvisioningDestinationDefinition definition) {
+        this.definition = definition;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ProvisioningTypeDefinition getType() {
+        return type;
+    }
+
+    public void setType(ProvisioningTypeDefinition type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder(this.getClass().getSimpleName());
+        sb.append("[");
+        sb.append("id=").append(id);
+        sb.append(", name='").append(name).append('\'');
+        sb.append(", configuration=").append(configuration);
+        sb.append(", definition.id=").append(definition.getId());
+        sb.append(", provisioning.type.name").append(type.getName());
+        addToString(sb);
+        sb.append(']');
+        return sb.toString();
+    }
+
+    protected void addToString(StringBuilder bld) {
+
+    }
+}

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ProvisioningDestinationDefinition.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ProvisioningDestinationDefinition.java
@@ -1,0 +1,214 @@
+package org.rhq.core.domain.provisioning;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.PostLoad;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+import javax.ws.rs.core.MediaType;
+
+import org.rhq.core.domain.resource.ResourceType;
+import org.rhq.core.domain.util.StringUtils;
+
+/**
+ * @author Lukas Krejci
+ */
+@Entity
+@Table(name = "RHQ_PRV_DEST_DEF")
+public final class ProvisioningDestinationDefinition implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @Column(name = "ID", nullable = false)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "RHQ_PRV_DEST_DEF_ID_SEQ")
+    private int id;
+
+    @Column(name = "NAME", nullable = false)
+    private String name;
+
+    @Column(name = "DISPLAY_NAME")
+    private String displayName;
+
+    @Column(name = "DESCRIPTION")
+    private String description;
+
+    private transient Set<MediaType> applicableMediaTypes;
+
+    @Column(name = "MEDIA_TYPES", length = 2048)
+    private String applicableMediaTypesString;
+
+    private transient Set<String> allowedFileExtensions;
+
+    @Column(name = "FILE_EXTS", length = 1024)
+    private String allowedFileExtensionsString;
+
+    @JoinColumn(name = "RESOURCE_TYPE_ID", referencedColumnName = "ID", nullable = false)
+    @ManyToOne(optional = false, fetch = FetchType.EAGER)
+    private ResourceType definingResourceType;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "definition")
+    private Set<ProvisioningDestination> destinations;
+
+    @PostLoad
+    protected void convertToLists() {
+        if (applicableMediaTypesString != null) {
+            applicableMediaTypes = MediaTypes.parse(applicableMediaTypesString);
+        } else {
+            applicableMediaTypes = Collections.emptySet();
+        }
+
+        if (allowedFileExtensions != null) {
+            allowedFileExtensions = new HashSet<String>(Arrays.asList(allowedFileExtensionsString.split(" ")));
+        } else {
+            allowedFileExtensions = Collections.emptySet();
+        }
+    }
+
+    @PrePersist @PreUpdate
+    protected void convertToStrings() {
+        if (applicableMediaTypes != null) {
+            applicableMediaTypesString = MediaTypes.toString(applicableMediaTypes);
+        } else {
+            applicableMediaTypesString = "";
+        }
+
+        if (allowedFileExtensions != null) {
+            allowedFileExtensionsString = StringUtils.join(allowedFileExtensions, " ", false);
+        }
+    }
+
+    public Set<String> getAllowedFileExtensions() {
+        if (allowedFileExtensions == null) {
+            allowedFileExtensions = new HashSet<String>();
+        }
+        return allowedFileExtensions;
+    }
+
+    public void setAllowedFileExtensions(Set<String> allowedFileExtensions) {
+        if (allowedFileExtensions == null) {
+            throw new IllegalArgumentException("allowedFileExtensions can't be null.");
+        }
+        this.allowedFileExtensions = allowedFileExtensions;
+    }
+
+    public Set<MediaType> getApplicableMediaTypes() {
+        if (applicableMediaTypes == null) {
+            applicableMediaTypes = new HashSet<MediaType>();
+        }
+        return applicableMediaTypes;
+    }
+
+    public void setApplicableMediaTypes(Set<MediaType> applicableMediaTypes) {
+        if (applicableMediaTypes == null) {
+            throw new IllegalArgumentException("applicableMediaTypes can't be null.");
+        }
+        this.applicableMediaTypes = applicableMediaTypes;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ResourceType getDefiningResourceType() {
+        return definingResourceType;
+    }
+
+    public void setDefiningResourceType(ResourceType definingResourceType) {
+        if (definingResourceType == null) {
+            throw new IllegalArgumentException("definingResourceType can't be null.");
+        }
+        this.definingResourceType = definingResourceType;
+    }
+
+    public Set<ProvisioningDestination> getDestinations() {
+        return destinations;
+    }
+
+    public void setDestinations(Set<ProvisioningDestination> destinations) {
+        this.destinations = destinations;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ProvisioningDestinationDefinition)) {
+            return false;
+        }
+
+        ProvisioningDestinationDefinition that = (ProvisioningDestinationDefinition) o;
+
+        if (definingResourceType != null ? !definingResourceType.equals(that.definingResourceType) :
+            that.definingResourceType != null) {
+            return false;
+        }
+        if (!name.equals(that.name)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + (definingResourceType != null ? definingResourceType.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ProvisioningDestinationDefinition[");
+        sb.append("name='").append(name).append('\'');
+        sb.append(", definingResourceType=").append(definingResourceType);
+        sb.append(']');
+        return sb.toString();
+    }
+
+
+}

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ProvisioningGroupDestination.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ProvisioningGroupDestination.java
@@ -1,0 +1,35 @@
+package org.rhq.core.domain.provisioning;
+
+import javax.persistence.CascadeType;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import org.rhq.core.domain.resource.group.ResourceGroup;
+
+/**
+ * @author Lukas Krejci
+ */
+@Entity
+@DiscriminatorValue("G")
+public final class ProvisioningGroupDestination extends ProvisioningDestination {
+    private static final long serialVersionUID = 1L;
+
+    @JoinColumn(name = "TARGET_RES_GROUP_ID", referencedColumnName = "ID", nullable = false)
+    @ManyToOne(optional = false, cascade = CascadeType.ALL)
+    private ResourceGroup targetResourceGroup;
+
+    public ResourceGroup getTargetResourceGroup() {
+        return targetResourceGroup;
+    }
+
+    public void setTargetResourceGroup(ResourceGroup targetResourceGroup) {
+        this.targetResourceGroup = targetResourceGroup;
+    }
+
+    @Override
+    protected void addToString(StringBuilder bld) {
+        bld.append(", targetResourceGroup.id=").append(targetResourceGroup.getId());
+    }
+}

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ProvisioningResourceDestination.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ProvisioningResourceDestination.java
@@ -1,0 +1,35 @@
+package org.rhq.core.domain.provisioning;
+
+import javax.persistence.CascadeType;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import org.rhq.core.domain.resource.Resource;
+
+/**
+ * @author Lukas Krejci
+ */
+@Entity
+@DiscriminatorValue("R")
+public final class ProvisioningResourceDestination extends ProvisioningDestination {
+    private static final long serialVersionUID = 1L;
+
+    @JoinColumn(name = "TARGET_RES_ID", referencedColumnName = "ID", nullable = false)
+    @ManyToOne(cascade = CascadeType.ALL)
+    private Resource targetResource;
+
+    public Resource getTargetResource() {
+        return targetResource;
+    }
+
+    public void setTargetResource(Resource targetResource) {
+        this.targetResource = targetResource;
+    }
+
+    @Override
+    protected void addToString(StringBuilder bld) {
+        bld.append(", targetResource.id=").append(targetResource.getId());
+    }
+}

--- a/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ProvisioningTypeDefinition.java
+++ b/modules/core/domain/src/main/java/org/rhq/core/domain/provisioning/ProvisioningTypeDefinition.java
@@ -1,0 +1,162 @@
+package org.rhq.core.domain.provisioning;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.PostLoad;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+import javax.ws.rs.core.MediaType;
+
+import org.rhq.core.domain.configuration.definition.ConfigurationDefinition;
+import org.rhq.core.domain.resource.ResourceType;
+import org.rhq.core.domain.util.StringUtils;
+
+/**
+ * @author Lukas Krejci
+ */
+@Entity
+@Table(name = "RHQ_PRV_TYPE_DEF")
+public final class ProvisioningTypeDefinition implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @Column(name = "ID", nullable = false)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "RHQ_PRV_TYPE_DEF_ID_SEQ")
+    private int id;
+
+    @Column(name = "NAME", nullable = false)
+    private String name;
+
+    @JoinColumn(name = "RESOURCE_TYPE_ID", referencedColumnName = "ID", nullable = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private ResourceType handlerResourceType;
+
+    @JoinColumn(name = "DEST_CONF_DEF_ID", referencedColumnName = "ID")
+    @OneToOne(cascade = CascadeType.ALL)
+    private ConfigurationDefinition destinationConfigurationDefinition;
+
+    private transient Set<MediaType> applicableMediaTypes;
+
+    @Column(name = "MEDIA_TYPES")
+    private String applicableMediaTypesString;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "definition")
+    private Set<ProvisioningDestination> destinations;
+
+    @PostLoad
+    protected void fromStrings() {
+        if (applicableMediaTypesString != null) {
+            applicableMediaTypes = MediaTypes.parse(applicableMediaTypesString);
+        } else {
+            applicableMediaTypes = Collections.emptySet();
+        }
+    }
+
+    @PrePersist @PreUpdate
+    protected void toStrings() {
+        if (applicableMediaTypes == null) {
+            applicableMediaTypesString = "";
+        } else {
+            applicableMediaTypesString = StringUtils.join(applicableMediaTypes, " ", false);
+        }
+    }
+
+    public Set<MediaType> getApplicableMediaTypes() {
+        return applicableMediaTypes;
+    }
+
+    public void setApplicableMediaTypes(Set<MediaType> applicableMediaTypes) {
+        if (applicableMediaTypes == null) {
+            throw new IllegalArgumentException("applicableMediaTypes can't be null.");
+        }
+        this.applicableMediaTypes = applicableMediaTypes;
+    }
+
+    public ConfigurationDefinition getDestinationConfigurationDefinition() {
+        return destinationConfigurationDefinition;
+    }
+
+    public void setDestinationConfigurationDefinition(ConfigurationDefinition destinationConfigurationDefinition) {
+        this.destinationConfigurationDefinition = destinationConfigurationDefinition;
+    }
+
+    public ResourceType getHandlerResourceType() {
+        return handlerResourceType;
+    }
+
+    public void setHandlerResourceType(ResourceType handlerResourceType) {
+        this.handlerResourceType = handlerResourceType;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name can't be null.");
+        }
+        this.name = name;
+    }
+
+    public Set<ProvisioningDestination> getDestinations() {
+        return destinations;
+    }
+
+    public void setDestinations(Set<ProvisioningDestination> destinations) {
+        this.destinations = destinations;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ProvisioningTypeDefinition)) {
+            return false;
+        }
+
+        ProvisioningTypeDefinition that = (ProvisioningTypeDefinition) o;
+
+        if (!name.equals(that.name)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ProvisioningTypeDefinition[");
+        sb.append("name='").append(name).append('\'');
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/plugin/pc/provisioning/ContentRepositoryConnectorFacet.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/plugin/pc/provisioning/ContentRepositoryConnectorFacet.java
@@ -1,0 +1,150 @@
+package org.rhq.enterprise.server.plugin.pc.provisioning;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.rhq.core.domain.configuration.Configuration;
+import org.rhq.core.domain.criteria.ArtifactCriteria;
+import org.rhq.core.domain.provisioning.Artifact;
+
+/**
+ * Defines the contract for the connectors to external content repositories.
+ *
+ * @author Lukas Krejci
+ */
+public interface ContentRepositoryConnectorFacet {
+
+    /**
+     * Types of the links we create between different artifacts.
+     */
+    enum LinkType {
+        /**
+         * Bundle link exists between a bundle recipe and the individual bundle files that comprise the bundle.
+         */
+        BUNDLE,
+
+        /**
+         * A deployment link exists between a deployed artifact and the individual deployment artifacts that RHQ creates
+         * to give out the information about the deployments to the repository.
+         */
+        DEPLOYMENT
+    }
+
+    /**
+     * Queries the repository for artifacts matching the provided criteria. <p> It is up to the implementation to
+     * translate the criteria object into a query understood by the target content repository.
+     *
+     * @param criteria the criteria the artifacts need to match
+     * @return the list of artifacts from the remote repository matching the criteria
+     * @throws ContentRepositoryException
+     */
+    List<Artifact> query(ArtifactCriteria criteria) throws ContentRepositoryException;
+
+    /**
+     * Creates a new artifact in the remote repository.
+     *
+     * @param path               the path to store the artifact in including the name of the artifact
+     * @param version            the version of the artifact or null if the repository should attempt auto-detection
+     * @param artifactDefinition the additional definitions of the artifact as specified in the plugin descriptor
+     * @param metadata           the metadata to attach to the artifact
+     * @param content            the content of the artifact
+     * @return an artifact object representing the stored artifact in the repository
+     */
+    Artifact create(String path, String version, Configuration artifactDefinition, Map<String, String> metadata,
+        InputStream content) throws ContentRepositoryException;
+
+    /**
+     * Creates a new content-less artifact.
+     *
+     * @param path               the path to store the artifact in including the name of the artifact
+     * @param version            the version of the artifact or null if the repository should attempt auto-detection
+     * @param artifactDefinition the additional definitions of the artifact as specified in the plugin descriptor
+     * @param metadata           the metadata to attach to the artifact
+     * @return an artifact object representing the stored artifact in the repository
+     */
+    Artifact create(String path, String version, Configuration artifactDefinition, Map<String, String> metadata)
+        throws ContentRepositoryException;
+
+    /**
+     * Creates a link of given type between the two artifacts.
+     *
+     * @param from     the source artifact
+     * @param to       the target artifact
+     * @param linkType the type of the link to create between the artifacts
+     */
+    void createLink(Artifact from, Artifact to, LinkType linkType) throws ContentRepositoryException;
+
+    /**
+     * Obtains the metadata of an artifact from the repository.
+     *
+     * @param artifactIdentifier the unique identifier of the artifact in the repository
+     * @return the artifact object with the metadata of the artifact specified by the identifier
+     * @see org.rhq.core.domain.provisioning.Artifact#getIdentifier()
+     */
+    Artifact getMetadata(String artifactIdentifier) throws ContentRepositoryException;
+
+    /**
+     * Obtains the content of an artifact from the repository.
+     *
+     * @param artifactIdentifier the unique identifier of the artifact in the repository
+     * @return an input stream with the contents of the artifact
+     * @see org.rhq.core.domain.provisioning.Artifact#getIdentifier()
+     */
+    InputStream getContent(String artifactIdentifier) throws ContentRepositoryException;
+
+    /**
+     * Obtains a set of artifacts that are linked to the artifact specified by the identifier.
+     *
+     * @param artifactIdentifier the unique identifier of the artifact in the repository
+     * @param linkType           the type of the link
+     * @return the set of artifacts linked to the specified artifact
+     */
+    Set<Artifact> getLinkedArtifacts(String artifactIdentifier, LinkType linkType) throws ContentRepositoryException;
+
+    /**
+     * TODO is it right to have this method here? Update of the content should be accompanied by the change of the
+     * version.
+     *
+     * Updates the content of the artifact with the content from the input stream
+     *
+     * @param artifactIdentifier the unique identifier of the artifact in the repository
+     * @param content            the new content of the artifact
+     */
+    void updateContent(String artifactIdentifier, InputStream content) throws ContentRepositoryException;
+
+    /**
+     * Updates the metadata of the artifact. The provided metadata completely replaces the existing metadata of the
+     * artifact.
+     *
+     * @param artifactIdentifier the unique identifier of the artifact in the repository
+     * @param metadata           the metadata to set on the artifact
+     */
+    void updateMetadata(String artifactIdentifier, Map<String, String> metadata) throws ContentRepositoryException;
+
+    /**
+     * TODO this is a very dangerous action, because it will destroy the deployment history of the artifact, too. If we
+     * can get away without it, we should.
+     *
+     * Deletes the artifact from the repository.
+     *
+     * @param artifactIdentifier
+     */
+    void delete(String artifactIdentifier) throws ContentRepositoryException;
+
+    /**
+     * Connects to the repository.
+     *
+     * @param repositoryURI           the URI of the repository to connect to
+     * @param connectionConfiguration the connection configuration, the definition of the configuration is specified in
+     *                                the server plugin descriptor
+     */
+    void connect(URI repositoryURI, Configuration connectionConfiguration) throws ContentRepositoryException;
+
+    /**
+     * Disconnects from the repository and frees up all the resources associated with the connection.
+     */
+    void disconnect() throws ContentRepositoryException;
+}

--- a/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/plugin/pc/provisioning/ContentRepositoryException.java
+++ b/modules/enterprise/server/jar/src/main/java/org/rhq/enterprise/server/plugin/pc/provisioning/ContentRepositoryException.java
@@ -1,0 +1,23 @@
+package org.rhq.enterprise.server.plugin.pc.provisioning;
+
+/**
+ * @author Lukas Krejci
+ */
+public class ContentRepositoryException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public ContentRepositoryException() {
+    }
+
+    public ContentRepositoryException(Throwable cause) {
+        super(cause);
+    }
+
+    public ContentRepositoryException(String message) {
+        super(message);
+    }
+
+    public ContentRepositoryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/modules/enterprise/server/plugins/repositoryconnector-sramp/pom.xml
+++ b/modules/enterprise/server/plugins/repositoryconnector-sramp/pom.xml
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>rhq-enterprise-server-plugins-parent</artifactId>
+        <groupId>org.rhq</groupId>
+        <version>4.8.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rhq-serverplugin-repositoryconnector-sramp</artifactId>
+
+    <name>RHQ Enterprise Server S-RAMP Repository Connector Plugin</name>
+
+    <properties>
+        <sramp.version>0.1.2-SNAPSHOT</sramp.version>
+        <org.modeshape.version>3.2.0.Final</org.modeshape.version>
+        <org.jboss.resteasy.version>2.3.5.Final</org.jboss.resteasy.version>
+        <infinispan.version>5.2.5.Final</infinispan.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.overlord.sramp</groupId>
+            <artifactId>s-ramp-client</artifactId>
+            <version>${sramp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.overlord.sramp</groupId>
+            <artifactId>s-ramp-common</artifactId>
+            <version>${sramp.version}</version>
+        </dependency>
+
+        <!-- Test deps -->
+        <dependency>
+            <groupId>org.overlord.sramp</groupId>
+            <artifactId>s-ramp-client</artifactId>
+            <version>${sramp.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.overlord.sramp</groupId>
+            <artifactId>s-ramp-common</artifactId>
+            <version>${sramp.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.overlord.sramp</groupId>
+            <artifactId>s-ramp-server</artifactId>
+            <version>${sramp.version}</version>
+            <classifier>classes</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
+            <version>${org.modeshape.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr</artifactId>
+            <version>${org.modeshape.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.overlord.sramp</groupId>
+            <artifactId>s-ramp-repository-jcr-modeshape</artifactId>
+            <version>${sramp.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>tjws</artifactId>
+            <version>${org.jboss.resteasy.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <version>${infinispan.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludedGroups>${rhq.testng.excludedGroups}</excludedGroups>
+                    <!--
+                       <argLine>${jacoco.unit-test.args} -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</argLine>
+                    -->
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <!-- We need to copy over the S-RAMP client libs and their deps not present in our container (AS7) -->
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-rhq-plugins</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.overlord.sramp</groupId>
+                                    <artifactId>s-ramp-client</artifactId>
+                                    <version>${sramp.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.overlord.sramp</groupId>
+                                    <artifactId>s-ramp-api</artifactId>
+                                    <version>${sramp.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.overlord.sramp</groupId>
+                                    <artifactId>s-ramp-common</artifactId>
+                                    <version>${sramp.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.overlord.sramp</groupId>
+                                    <artifactId>s-ramp-atom</artifactId>
+                                    <version>${sramp.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.commons</groupId>
+                                    <artifactId>commons-compress</artifactId>
+                                    <version>1.4.1</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.tukaani</groupId>
+                                    <artifactId>xz</artifactId>
+                                    <version>1.0</version>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.outputDirectory}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <profiles>
+
+        <profile>
+            <id>dev</id>
+
+            <properties>
+                <rhq.rootDir>../../../../..</rhq.rootDir>
+                <rhq.containerDir>${rhq.rootDir}/${rhq.defaultDevContainerPath}</rhq.containerDir>
+                <rhq.deploymentDir>${rhq.containerDir}/${rhq.serverPluginDir}
+                </rhq.deploymentDir>
+            </properties>
+
+            <build>
+                <plugins>
+
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+
+                            <execution>
+                                <id>deploy</id>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <target>
+                                        <mkdir dir="${rhq.deploymentDir}"/>
+                                        <property name="deployment.file"
+                                                  location="${rhq.deploymentDir}/${project.build.finalName}.jar"/>
+                                        <echo>*** Updating ${deployment.file}...</echo>
+                                        <jar destfile="${deployment.file}" basedir="${project.build.outputDirectory}"/>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+
+                            <execution>
+                                <id>undeploy</id>
+                                <phase>clean</phase>
+                                <configuration>
+                                    <target>
+                                        <property name="deployment.file"
+                                                  location="${rhq.deploymentDir}/${project.build.finalName}.jar"/>
+                                        <echo>*** Deleting ${deployment.file}...</echo>
+                                        <delete file="${deployment.file}"/>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+
+                            <execution>
+                                <id>deploy-jar-meta-inf</id>
+                                <phase>package</phase>
+                                <configuration>
+                                    <target>
+                                        <property name="deployment.file"
+                                                  location="${rhq.deploymentDir}/${project.build.finalName}.jar"/>
+                                        <echo>*** Updating META-INF dir
+                                            in ${deployment.file}...
+                                        </echo>
+                                        <unjar src="${project.build.directory}/${project.build.finalName}.jar"
+                                               dest="${project.build.outputDirectory}">
+                                            <patternset>
+                                                <include name="META-INF/**"/>
+                                            </patternset>
+                                        </unjar>
+                                        <jar destfile="${deployment.file}"
+                                             manifest="${project.build.outputDirectory}/META-INF/MANIFEST.MF"
+                                             update="true">
+                                        </jar>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/modules/enterprise/server/plugins/repositoryconnector-sramp/src/main/java/org/rhq/enterprise/server/plugins/repositoryconnector/sramp/SrampConnector.java
+++ b/modules/enterprise/server/plugins/repositoryconnector-sramp/src/main/java/org/rhq/enterprise/server/plugins/repositoryconnector/sramp/SrampConnector.java
@@ -1,0 +1,354 @@
+package org.rhq.enterprise.server.plugins.repositoryconnector.sramp;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.oasis_open.docs.s_ramp.ns.s_ramp_v1.BaseArtifactType;
+import org.oasis_open.docs.s_ramp.ns.s_ramp_v1.DocumentArtifactType;
+import org.oasis_open.docs.s_ramp.ns.s_ramp_v1.Property;
+import org.oasis_open.docs.s_ramp.ns.s_ramp_v1.Relationship;
+import org.oasis_open.docs.s_ramp.ns.s_ramp_v1.Target;
+import org.overlord.sramp.atom.err.SrampAtomException;
+import org.overlord.sramp.client.SrampAtomApiClient;
+import org.overlord.sramp.client.SrampClientException;
+import org.overlord.sramp.client.query.ArtifactSummary;
+import org.overlord.sramp.client.query.QueryResultSet;
+import org.overlord.sramp.common.ArtifactType;
+
+import org.rhq.core.domain.configuration.Configuration;
+import org.rhq.core.domain.configuration.PropertySimple;
+import org.rhq.core.domain.criteria.ArtifactCriteria;
+import org.rhq.core.domain.provisioning.Artifact;
+import org.rhq.enterprise.server.plugin.pc.provisioning.ContentRepositoryConnectorFacet;
+import org.rhq.enterprise.server.plugin.pc.provisioning.ContentRepositoryException;
+
+/**
+ * @author Lukas Krejci
+ */
+public class SrampConnector implements ContentRepositoryConnectorFacet {
+    private URI repositoryURI;
+    private SrampAtomApiClient client;
+
+    private void checkClient() {
+        if (client == null) {
+            throw new ContentRepositoryException("Not connected to the server.");
+        }
+    }
+
+    @Override
+    public List<Artifact> query(ArtifactCriteria criteria) throws ContentRepositoryException {
+        checkClient();
+
+        //TODO the criteria should explicitly state which properties to fetch so that we can then later on
+        //init those props in the "convert" method. The below code is not ready for that...
+
+        String q = composeQuery(criteria);
+        try {
+            QueryResultSet results = client.buildQuery(q).query();
+            List<Artifact> ret = new ArrayList<Artifact>();
+
+            for (ArtifactSummary as : results) {
+                ret.add(convert(as));
+            }
+
+            return ret;
+        } catch (Exception e) {
+            throw new ContentRepositoryException("Could not perform the query: " + criteria, e);
+        }
+    }
+
+    @Override
+    public Artifact create(String path, String version, Configuration artifactDefinition, Map<String, String> metadata,
+        InputStream content) {
+        checkClient();
+
+        BaseArtifactType srampArtifact = instantiateArtifact(path, version, artifactDefinition, metadata);
+
+        try {
+            srampArtifact = client.uploadArtifact(srampArtifact, content);
+
+            return convert(srampArtifact);
+        } catch (Exception e) {
+            throw new ContentRepositoryException(
+                "Failed to create artifact on path " + path + " in version " + version + " with definition " +
+                    artifactDefinition + " from content.", e);
+        }
+    }
+
+    @Override
+    public Artifact create(String path, String version, Configuration artifactDefinition,
+        Map<String, String> metadata) {
+        checkClient();
+
+        BaseArtifactType srampArtifact = instantiateArtifact(path, version, artifactDefinition, metadata);
+
+        try {
+            srampArtifact = client.createArtifact(srampArtifact);
+
+            return convert(srampArtifact);
+        } catch (Exception e) {
+            throw new ContentRepositoryException(
+                "Failed to create artifact on path " + path + " in version " + version + " with definition " +
+                    artifactDefinition + ".", e);
+        }
+    }
+
+    @Override
+    public void createLink(Artifact from, Artifact to, LinkType linkType) {
+        checkClient();
+
+        BaseArtifactType srampFrom = null;
+        BaseArtifactType srampTo = null;
+
+        try {
+            srampFrom = client.getArtifactMetaData(from.getIdentifier());
+        } catch (SrampClientException e) {
+            throw new ContentRepositoryException("Error while fetching the metadata of artifact " + from, e);
+        } catch (SrampAtomException e) {
+            throw new ContentRepositoryException("Error while fetching the metadata of artifact " + from, e);
+        }
+
+        try {
+            srampTo = client.getArtifactMetaData(to.getIdentifier());
+        } catch (SrampClientException e) {
+            throw new ContentRepositoryException("Error while fetching the metadata of artifact " + to, e);
+        } catch (SrampAtomException e) {
+            throw new ContentRepositoryException("Error while fetching the metadata of artifact " + to, e);
+        }
+
+        Relationship rel = new Relationship();
+        Target relTarget = new Target();
+        relTarget.setHref(to.getIdentifier());
+        rel.getRelationshipTarget().add(relTarget);
+        rel.setRelationshipType(getRelationshipName(linkType));
+
+        srampFrom.getRelationship().add(rel);
+
+        try {
+            client.updateArtifactMetaData(srampFrom);
+        } catch (SrampClientException e) {
+            throw new ContentRepositoryException("Error while updating the metadata of artifact " + from, e);
+        } catch (SrampAtomException e) {
+            throw new ContentRepositoryException("Error while fetching the metadata of artifact " + from, e);
+        }
+    }
+
+    @Override
+    public Artifact getMetadata(String artifactIdentifier) {
+        checkClient();
+        try {
+            BaseArtifactType sramp = client.getArtifactMetaData(artifactIdentifier);
+            return convert(sramp);
+        } catch (SrampClientException e) {
+            throw new ContentRepositoryException("Error while fetching the metadata of artifact with identifier " + artifactIdentifier, e);
+        } catch (SrampAtomException e) {
+            throw new ContentRepositoryException("Error while fetching the metadata of artifact with identifier " + artifactIdentifier, e);
+        }
+    }
+
+    @Override
+    public InputStream getContent(String artifactIdentifier) {
+        checkClient();
+
+        Artifact a = getMetadata(artifactIdentifier);
+        ArtifactType at = ArtifactType.valueOf(a.getDefinition().getSimpleValue("artifactType"));
+
+        try {
+            return client.getArtifactContent(at, artifactIdentifier);
+        } catch (SrampClientException e) {
+            throw new ContentRepositoryException("Error while fetching the content of artifact with identifier " + artifactIdentifier, e);
+        } catch (SrampAtomException e) {
+            throw new ContentRepositoryException("Error while fetching the content of artifact with identifier " + artifactIdentifier, e);
+        }
+    }
+
+    @Override
+    public Set<Artifact> getLinkedArtifacts(String artifactIdentifier, LinkType linkType) {
+        checkClient();
+
+        try {
+            BaseArtifactType srampArtifact = client.getArtifactMetaData(artifactIdentifier);
+            String relationshipName = getRelationshipName(linkType);
+
+            HashSet<Artifact> ret = new HashSet<Artifact>();
+            for(Relationship r : srampArtifact.getRelationship()) {
+                if (relationshipName.equals(r.getRelationshipType())) {
+                    for(Target t : r.getRelationshipTarget()) {
+                        String targetUuid = t.getHref();
+                        BaseArtifactType targetMetadata = client.getArtifactMetaData(targetUuid);
+                        ret.add(convert(targetMetadata));
+                    }
+                }
+            }
+
+            return ret;
+        } catch (SrampClientException e) {
+            throw new ContentRepositoryException("Error while querying the linked artifacts of artifact with identifier " + artifactIdentifier, e);
+        } catch (SrampAtomException e) {
+            throw new ContentRepositoryException("Error while querying the linked artifacts of artifact with identifier " + artifactIdentifier, e);
+        }
+    }
+
+    @Override
+    public void updateContent(String artifactIdentifier, InputStream content) {
+        checkClient();
+
+        try {
+            BaseArtifactType srampArtifact = client.getArtifactMetaData(artifactIdentifier);
+            client.updateArtifactContent(srampArtifact, content);
+        } catch (SrampClientException e) {
+            throw new ContentRepositoryException("Error while updating content of artifact with identifier " + artifactIdentifier, e);
+        } catch (SrampAtomException e) {
+            throw new ContentRepositoryException("Error while updating content of artifact with identifier " + artifactIdentifier, e);
+        }
+    }
+
+    @Override
+    public void updateMetadata(String artifactIdentifier, Map<String, String> metadata) {
+        checkClient();
+
+        try {
+            BaseArtifactType srampArtifact = client.getArtifactMetaData(artifactIdentifier);
+            srampArtifact.getProperty().clear();
+            for(Map.Entry<String, String> e : metadata.entrySet()) {
+                Property p = new Property();
+                p.setPropertyName(e.getKey());
+                p.setPropertyValue(e.getValue());
+                srampArtifact.getProperty().add(p);
+            }
+
+            client.updateArtifactMetaData(srampArtifact);
+        } catch (SrampClientException e) {
+            throw new ContentRepositoryException("Error while updating metadata of artifact with identifier " + artifactIdentifier, e);
+        } catch (SrampAtomException e) {
+            throw new ContentRepositoryException("Error while updating metadata of artifact with identifier " + artifactIdentifier, e);
+        }
+    }
+
+    @Override
+    public void delete(String artifactIdentifier) {
+        checkClient();
+
+        try {
+            BaseArtifactType srampArtifact = client.getArtifactMetaData(artifactIdentifier);
+            client.deleteArtifact(artifactIdentifier, ArtifactType.valueOf(srampArtifact.getArtifactType()));
+        } catch (SrampClientException e) {
+            throw new ContentRepositoryException("Error while deleting the artifact with identifier " + artifactIdentifier, e);
+        } catch (SrampAtomException e) {
+            throw new ContentRepositoryException("Error while deleting the artifact with identifier " + artifactIdentifier, e);
+        }
+    }
+
+    @Override
+    public void connect(URI repositoryURI, Configuration connectionConfiguration) throws ContentRepositoryException {
+        disconnect();
+
+        String username = null;
+        String password = null;
+
+        if (connectionConfiguration != null) {
+            username = connectionConfiguration.getSimpleValue("username");
+            password = connectionConfiguration.getSimpleValue("password");
+        }
+
+        try {
+            client = new SrampAtomApiClient(repositoryURI.toString(), username, password, true);
+
+            //if we were able to establish the client, let's store the URI, too
+            this.repositoryURI = repositoryURI;
+        } catch (Exception e) {
+            throw new ContentRepositoryException("Failed to connect to the repository " + repositoryURI, e);
+        }
+    }
+
+    @Override
+    public void disconnect() {
+        client = null;
+    }
+
+    private String composeQuery(ArtifactCriteria criteria) {
+        return null;  //TODO implement
+    }
+
+    private Artifact convert(BaseArtifactType a) {
+        String mediaType = null;
+        if (a instanceof DocumentArtifactType) {
+            mediaType = ((DocumentArtifactType) a).getContentType();
+        }
+
+        Artifact ret = new Artifact(repositoryURI, a.getUuid(), a.getName(), mediaType, a.getVersion());
+
+        for (Property p : a.getProperty()) {
+            ret.getMetadata().put(p.getPropertyName(), p.getPropertyValue());
+        }
+
+        Configuration definition = new Configuration();
+        definition.put(new PropertySimple("artifactType", a.getArtifactType().name()));
+
+        ret.setDefinition(definition);
+
+        return ret;
+    }
+
+    private Artifact convert(ArtifactSummary as) {
+        String mediaType = null;
+        if (as.getType().newArtifactInstance() instanceof DocumentArtifactType) {
+            mediaType = as.getCustomPropertyValue("contentType");
+        }
+
+        String version = as.getCustomPropertyValue("version");
+
+        Artifact ret = new Artifact(repositoryURI, as.getUuid(), as.getName(), mediaType, version);
+
+        Configuration definition = new Configuration();
+        definition.put(new PropertySimple("artifactType", as.getType().getArtifactType().name()));
+
+        ret.setDefinition(definition);
+
+        return ret;
+    }
+
+    private static String getName(String path) {
+        int lastSlash = path.lastIndexOf('/');
+        if (lastSlash == -1) {
+            return path;
+        } else {
+            return path.substring(lastSlash + 1);
+        }
+    }
+
+    private BaseArtifactType instantiateArtifact(String path, String version, Configuration artifactDefinition,
+        Map<String, String> metadata) {
+        String artifactType = artifactDefinition.getSimpleValue("artifactType");
+        BaseArtifactType srampArtifact = ArtifactType.valueOf(artifactType).newArtifactInstance();
+        srampArtifact.setVersion(version);
+        srampArtifact.setName(getName(path));
+        List<Property> srampProperties = srampArtifact.getProperty();
+
+        for (Map.Entry<String, String> e : metadata.entrySet()) {
+            Property p = new Property();
+            p.setPropertyName(e.getKey());
+            p.setPropertyValue(e.getValue());
+
+            srampProperties.add(p);
+        }
+
+        return srampArtifact;
+    }
+
+    private static String getRelationshipName(LinkType linkType) {
+        switch (linkType) {
+        case BUNDLE:
+            return "rhq.bundle-file";
+        case DEPLOYMENT:
+            return "rhq.deployment";
+        default:
+            throw new IllegalStateException("Unknown LinkType value");
+        }
+    }
+}

--- a/modules/enterprise/server/plugins/repositoryconnector-sramp/src/main/resources/META-INF/rhq-serverplugin.xml
+++ b/modules/enterprise/server/plugins/repositoryconnector-sramp/src/main/resources/META-INF/rhq-serverplugin.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<repositoryconnector-plugin name="repositoryconnector-sramp"
+                    displayName="RepositoryConnector:S-RAMP" xmlns="urn:xmlns:rhq-serverplugin.repositoryconnector"
+                    xmlns:c="urn:xmlns:rhq-configuration" xmlns:serverplugin="urn:xmlns:rhq-serverplugin"
+                    package="org.rhq.enterprise.server.plugins.repositoryconnector.sramp"
+                    description="A package type for CLI scripts.">
+
+    <serverplugin:help>
+        This plugin makes it possible to connect to an S-RAMP repository.
+    </serverplugin:help>
+
+    <serverplugin:plugin-configuration>
+        <c:simple-property name="username" displayName="User Name"/>
+        <c:simple-property name="password" type="password" />
+    </serverplugin:plugin-configuration>
+
+    <artifact-definition>
+        <c:simple-property name="artifactType" displayName="S-RAMP Type" required="true">
+            <c:description>
+                The type of the S-RAMP artifact. This must be supplied manually because S-RAMP doesn't provide a way
+                of autodetecting these types. You can select from the list of the predefined standard S-RAMP artifact
+                types or you can supply the name of a custom type. Please refer to S-RAMP documentation to understand
+                what the types are and how they are used within S-RAMP.
+            </c:description>
+            <c:property-options allowCustomValue="true">
+                <c:option value="Document" name="Document" />
+                <c:option value="XmlDocument" name="XML Document" />
+                <c:option value="XsdDocument" name="XSD Document" />
+                <c:option value="WsdlDocument" name="WSDL Document" />
+                <c:option value="PolicyDocument" name="Policy Document" />
+            </c:property-options>
+        </c:simple-property>
+    </artifact-definition>
+
+</repositoryconnector-plugin>

--- a/modules/enterprise/server/plugins/repositoryconnector-sramp/src/test/java/org/rhq/enterprise/server/plugins/repositoryconnector/sramp/test/SrampConnectorTest.java
+++ b/modules/enterprise/server/plugins/repositoryconnector-sramp/src/test/java/org/rhq/enterprise/server/plugins/repositoryconnector/sramp/test/SrampConnectorTest.java
@@ -1,0 +1,72 @@
+package org.rhq.enterprise.server.plugins.repositoryconnector.sramp.test;
+
+import java.net.URI;
+import java.util.Collections;
+
+import org.overlord.sramp.client.AbstractNoAuditingClientTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.rhq.core.domain.configuration.Configuration;
+import org.rhq.core.domain.configuration.PropertySimple;
+import org.rhq.core.domain.provisioning.Artifact;
+import org.rhq.enterprise.server.plugins.repositoryconnector.sramp.SrampConnector;
+
+/**
+ * @author Lukas Krejci
+ */
+@Test
+public class SrampConnectorTest extends AbstractNoAuditingClientTest {
+
+    private SrampConnector connector;
+
+    @BeforeClass
+    public void baseResourceTestSetup() throws Exception {
+        before();
+    }
+
+    @BeforeClass(dependsOnMethods = "baseResourceTestSetup")
+    public void setup() throws Exception {
+        setUp();
+    }
+
+    @BeforeClass(dependsOnMethods = "setup")
+    public void connect() throws Exception {
+        connector = new SrampConnector();
+        connector.connect(URI.create("http://localhost:8081"), new Configuration());
+    }
+
+    @AfterClass
+    public void disconnect() throws Exception {
+        connector.disconnect();
+        connector = null;
+    }
+
+    @AfterClass(dependsOnMethods = "disconnect")
+    public void tearDown() {
+        cleanup();
+    }
+
+    @AfterClass
+    public void baseResourceTestTearDown() throws Exception {
+        after();
+    }
+
+    @BeforeMethod
+    public void cleanRepository() {
+        super.cleanRepository();
+    }
+
+    public void testQuerying() throws Exception {
+        //TODO implement
+    }
+
+    public void testCreateArtifact() throws Exception {
+        Configuration config = new Configuration();
+        config.put(new PropertySimple("artifactType", "Document"));
+
+        Artifact a = connector.create("kachny.txt", "1.0", config, Collections.<String, String>emptyMap());
+    }
+}

--- a/modules/enterprise/server/xml-schemas/src/main/resources/rhq-serverplugin-repositoryconnector.xsd
+++ b/modules/enterprise/server/xml-schemas/src/main/resources/rhq-serverplugin-repositoryconnector.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:serverplugin="urn:xmlns:rhq-serverplugin" xmlns:config="urn:xmlns:rhq-configuration"
+           xmlns:repositoryconnector="urn:xmlns:rhq-serverplugin.repositoryconnector"
+           targetNamespace="urn:xmlns:rhq-serverplugin.repositoryconnector"
+           elementFormDefault="qualified" jaxb:version="2.0"
+           xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" blockDefault="">
+
+    <xs:import namespace="urn:xmlns:rhq-serverplugin"
+               schemaLocation="rhq-serverplugin.xsd"/>
+    <xs:import namespace="urn:xmlns:rhq-configuration"
+               schemaLocation="rhq-configuration.xsd" />
+
+    <xs:annotation>
+        <xs:documentation>
+            Schema for repository connector plugins.
+        </xs:documentation>
+        <xs:appinfo>
+            <jaxb:schemaBindings>
+                <jaxb:package
+                        name="org.rhq.enterprise.server.xmlschema.generated.serverplugin.repositoryconnector"/>
+            </jaxb:schemaBindings>
+        </xs:appinfo>
+    </xs:annotation>
+
+    <xs:element name="repositoryconnector-plugin"
+                type="repositoryconnector:RepositoryConnectorPluginDescriptorType"
+                substitutionGroup="serverplugin:server-plugin">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a server-side repository connector plugin. Repository connectors are used to connect to
+                remote content repositories and provide an interoperability bridge between the repositories and RHQ.
+            </xs:documentation>
+            <xs:appinfo>
+                <jaxb:class name="RepositoryConnectorPluginElement"/>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="RepositoryConnectorPluginDescriptorType">
+        <xs:complexContent>
+            <xs:extension base="serverplugin:ServerPluginDescriptorType">
+                <xs:sequence>
+                    <xs:element name="artifact-definition" minOccurs="0" maxOccurs="1" type="config:configuration">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Specifies the additional definition of an artifact. This is distinct from
+                                the metadata, because this definition enhances the basic set of attributes describing
+                                what an artifact "is". Metadata merely provide additional information but do not contribute
+                                to the "type" of the artifact.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
There is a whole lot of changes that need to happen on the server-side.

The most important one is the notion of storing the deployable artifacts and also the information about deployments into a 3rd party repository. For that a concept of repository-connector server-side plugin is introduced (and S-RAMP connector is provided as a default prototype impl of that).

The basis for this design is the https://docs.jboss.org/author/display/RHQ/Server-side+Storage wiki page.

This is by no means finished and serves more as a basis for discussion on a detailed code-level rather than a ready-to-merge impl.

Note also that we are currently investigating the possibility of completely replacing our server-side provisioning solution with dtgov (https://github.com/Governance/dtgov).
